### PR TITLE
Fix globalThis.crypto bug for SRR / NextJS applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ const token = await getTokenFromGCPServiceAccount({ serviceAccountJSON, aud, cry
 ~~~
 
 
-## Node Usage (version >= 15)
+## Node Usage (version 15+)
 
 Node 15 introduces the [Web Crypto API](https://nodejs.org/api/webcrypto.html).  When using NextJS, you may need to pass in the native Node `webcrypto` lib to get both SSR and webpack to work during dev mode.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const response = await fetch(docUrl, { headers })
 const documentObj =  await response.json()
 ~~~
 
-## Node Usage
+## Node Usage (version <=14)
 
 We use the `node-webcrypto-ossl` package to imitate the `Web Crypto API` in Node.
 
@@ -119,6 +119,26 @@ const serviceAccountJSON = { ... }
 const aud = `https://firestore.googleapis.com/google.firestore.v1.Firestore`
 
 const token = await getTokenFromGCPServiceAccount({ serviceAccountJSON, aud, cryptoImpl } )
+
+<... SAME AS CLOUDFLARE WORKERS ...>
+~~~
+
+
+## Node Usage (version >= 15)
+
+Node 15 introduces the [Web Crypto API](https://nodejs.org/api/webcrypto.html).  When using NextJS, you may need to pass in the native Node `webcrypto` lib to get both SSR and webpack to work during dev mode.
+
+~~~js
+const { getTokenFromGCPServiceAccount } = require('@sagi.io/workers-jwt')
+
+const serviceAccountJSON = { ... }
+const aud = 'https://firestore.googleapis.com/google.firestore.v1.Firestore';
+
+const token = await getTokenFromGCPServiceAccount({ 
+  serviceAccountJSON, 
+  aud, 
+  cryptoImpl: globalThis.crypto || require('crypto').webcrypto,
+});
 
 <... SAME AS CLOUDFLARE WORKERS ...>
 ~~~

--- a/src/jwt.js
+++ b/src/jwt.js
@@ -43,7 +43,7 @@ export const getToken = async ({
   }
 
   const privateKeyDER = getDERfromPEM(privateKeyPEM);
-  const privateKey = await crypto.subtle.importKey(
+  const privateKey = await globalThis.crypto.subtle.importKey(
     'pkcs8',
     privateKeyDER,
     algorithm,
@@ -55,7 +55,7 @@ export const getToken = async ({
   const encodedMessage = getEncodedMessage(header, payload);
   const encodedMessageArrBuf = str2ab(encodedMessage);
 
-  const signatureArrBuf = await crypto.subtle.sign(
+  const signatureArrBuf = await globalThis.crypto.subtle.sign(
     algorithm,
     privateKey,
     encodedMessageArrBuf


### PR DESCRIPTION
This PR fixes a bug that blocks passing in the `cryptoImpl` field to the `getTokenFromGCPServiceAccount`.

It also explains how to pass in the native Node 15+ crypto library which is helpful when using frameworks like NextJS.