### PR TITLE
[FIX] includes types file in published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 *
-!index.js
+!/index.*
 !/lib/*
 !package.json
 !README.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sagi.io/workers-jwt",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Generate JWTs on Cloudflare Workers using the WebCrypto API",
   "author": "Sagi Kedmi <git@sagi.io> (https://sagi.io)",
   "homepage": "https://sagi.io",


### PR DESCRIPTION
Continue #26
Resolve #19

Didn't check the pack for my previous change. The definition file is not included in version 0.0.25

This changeset includes any "index" files on the root directory

```diff
npm notice 
npm notice 📦  @sagi.io/workers-jwt@0.0.26
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 5.5kB README.md   
+ npm notice 3.0kB index.d.ts
npm notice 137B  index.js    
npm notice 3.0kB lib/jwt.js  
npm notice 1.1kB lib/utils.js
npm notice 1.2kB package.json
npm notice === Tarball Details === 
npm notice name:          @sagi.io/workers-jwt                    
npm notice version:       0.0.26                                  
npm notice filename:      sagi.io-workers-jwt-0.0.26.tgz          
npm notice package size:  4.5 kB                                  
npm notice unpacked size: 12.1 kB                                 
npm notice shasum:        a795444889f30ae7432c20d0fb8199bbf7b4467b
npm notice integrity:     sha512-U+MK6KNYZY+hg[...]iWROhfQ4xvstw==
npm notice total files:   6                                       
npm notice 
sagi.io-workers-jwt-0.0.25.tgz
```